### PR TITLE
fix: allow native build scripts for sharp and unrs-resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nextstarter-lite",
   "version": "1.0.0",
   "private": true,
+  "trustedDependencies": ["sharp", "unrs-resolver"],
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+# Allow the native build scripts these transitive dependencies need.
+# pnpm 10+ blocks dependency build scripts by default; without this,
+# `pnpm install` reports ERR_PNPM_IGNORED_BUILDS for sharp/unrs-resolver.
+#
+# `allowBuilds` is the pnpm 11+ setting; `onlyBuiltDependencies` is the
+# pnpm 10.x equivalent. Both are listed so the template installs cleanly
+# regardless of which pnpm version the user has. The unused key is ignored.
+allowBuilds:
+  sharp: true
+  unrs-resolver: true
+onlyBuiltDependencies:
+  - sharp
+  - unrs-resolver


### PR DESCRIPTION
## Problem

pnpm 10+ and bun block dependency lifecycle scripts by default. On a fresh install this surfaces as:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, unrs-resolver@1.12.2
```

Both are transitive native dependencies (`sharp` via `next`, `unrs-resolver` via the eslint import resolver) that genuinely need their build step to produce native binaries.

## Fix

Allow-list the two packages for every package manager the scaffolder (`create-nextstarter`) offers:

- **`pnpm-workspace.yaml`** — `allowBuilds` (pnpm 11+) **and** `onlyBuiltDependencies` (pnpm 10.x). The unused key is ignored, so the template installs cleanly on either pnpm major.
- **`package.json` `trustedDependencies`** — the bun equivalent.

npm and yarn run these scripts by default and need no change.

## Verification

Clean installs run end-to-end with no ignored-build warning and sharp's native binary present (`sharp-darwin-arm64.node`):

- ✅ pnpm 11.7.0 — exit 0, no `ERR_PNPM_IGNORED_BUILDS`
- ✅ bun 1.3.14 — exit 0, no blocked-scripts notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)