### PR TITLE
Add premium (Pro) upsell content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 NEXT_PUBLIC_SITE_URL="http://localhost:3000/"
 NEXT_PUBLIC_SITE_NAME="NextStarter"
 NEXT_PUBLIC_SITE_META_DESCRIPTION="A modern Next.js boilerplate for building production-ready web applications."
+# Destination for the "Upgrade to Pro" call-to-action on the landing page.
+# Defaults to the marketing site; point it at your checkout/listing URL.
+NEXT_PUBLIC_PRO_URL="https://www.nextstarter.app/"

--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,28 @@ NEXT_PUBLIC_SITE_URL="http://localhost:3000/"
 NEXT_PUBLIC_SITE_NAME="NextStarter"
 NEXT_PUBLIC_SITE_META_DESCRIPTION="A modern Next.js boilerplate for building production-ready web applications."
 # Destination for the "Upgrade to Pro" call-to-action on the landing page.
-# Defaults to the marketing site; point it at your checkout/listing URL.
+# Point this at your Polar checkout link (Polar → Products → Checkout Links),
+# e.g. "https://buy.polar.sh/polar_cl_xxxxx". Falls back to the marketing site.
 NEXT_PUBLIC_PRO_URL="https://www.nextstarter.app/"
+
+# --- Post-purchase (/thanks) ---
+# Polar redirects buyers to /thanks after checkout. Set this as the "Success URL"
+# on the checkout link, optionally with the session id:
+#   https://www.nextstarter.app/thanks?checkout_id={CHECKOUT_ID}
+# Polar customer portal for your organization — where buyers sign in with their
+# checkout email to claim benefits (the private repo invite) and get invoices.
+NEXT_PUBLIC_POLAR_PORTAL_URL="https://polar.sh/742-studios/portal"
+# Support address shown on /thanks when an order or repo invite needs help.
+NEXT_PUBLIC_SUPPORT_EMAIL="bill@billdean.me"
+
+# --- Checkout smoke test (npm run test:checkout) ---
+# Only needed to run the on-demand checkout smoke test; the app ignores these.
+# The Polar sandbox (https://sandbox.polar.sh) is a fully separate instance:
+# its own account, organization, product, benefit, and token. A production
+# token will NOT work against it. Leave these blank and the script tells you
+# what is missing rather than touching anything live.
+POLAR_SANDBOX_TOKEN=""
+POLAR_SANDBOX_CHECKOUT_URL=""
+# Optional — the sandbox GitHub-repository benefit id, to also assert that
+# paying actually granted repo access.
+POLAR_SANDBOX_BENEFIT_ID=""

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,6 +18,12 @@ jobs:
       NEXT_PUBLIC_SITE_URL: https://www.nextstarter.app
       NEXT_PUBLIC_SITE_NAME: NextStarter
       NEXT_PUBLIC_SITE_META_DESCRIPTION: A modern Next.js boilerplate for building production-ready web applications.
+      # Polar checkout link for the "Get NextStarter Pro" CTA. Kept as a repo
+      # variable (Settings → Secrets and variables → Actions → Variables) rather
+      # than hardcoded, so the link can change without a commit and forks of this
+      # starter aren't pinned to someone else's storefront. When it is unset the
+      # CTA assertion skips; when set, CI proves the button really points at it.
+      NEXT_PUBLIC_PRO_URL: ${{ vars.NEXT_PUBLIC_PRO_URL }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: millionco/react-doctor@v2
         # Advisory by default: React Doctor reports findings on every PR — a

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ A modern Next.js boilerplate to ship production-ready projects fast — with Typ
 
 **[Live Demo](https://www.nextstarter.app/)**
 
+> **This is the free version of NextStarter.** [NextStarter Pro](https://www.nextstarter.app/)
+> adds authentication, a database, Stripe billing, email, a dashboard, admin,
+> internationalization, and more — a complete SaaS foundation.
+> [See what's included ↓](#upgrade-to-pro)
+
 ## Tech Stack
 
 | Layer      | Technology                                                                                      |
@@ -69,6 +74,31 @@ A modern Next.js boilerplate to ship production-ready projects fast — with Typ
 - `next/image` for optimized images
 - Static generation for sitemap and robots metadata
 - Custom 404 page
+
+---
+
+## Upgrade to Pro
+
+This free starter gives you a polished, accessible marketing landing page with
+testing and tooling built in. **NextStarter Pro** turns it into a complete SaaS
+foundation.
+
+**Everything in the free version, plus:**
+
+- 🔐 Authentication (Clerk) — sign-in, protected routes, user profile
+- 🗄️ Database (Prisma + PostgreSQL) — a user-owned CRUD example
+- ✉️ Transactional email (Resend) and 💳 Stripe subscriptions
+- 📊 Dashboard app shell + a protected admin panel
+- 📝 MDX blog and a validated contact form
+- 🌍 Internationalization — English, Spanish, and Arabic (RTL)
+- 🛡️ Security headers, CSP, and API rate limiting
+- 🚀 Waitlist mode, PostHog analytics, and Sentry error tracking
+- 📚 Comprehensive documentation
+
+**$199 one-time** — lifetime access and updates via a private GitHub repo (just
+`git pull` to update).
+
+**[Get NextStarter Pro →](https://www.nextstarter.app/)**
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "npx playwright test",
+    "test:checkout": "node scripts/checkout-smoke.mjs",
     "doctor": "npx react-doctor@latest"
   },
   "dependencies": {

--- a/scripts/checkout-smoke.mjs
+++ b/scripts/checkout-smoke.mjs
@@ -1,0 +1,233 @@
+/* eslint-disable no-console */
+/**
+ * On-demand checkout smoke test against the Polar **sandbox**.
+ *
+ * Deliberately not part of `npm run test`: it drives Polar's hosted checkout,
+ * which is third-party markup that can change without notice. Keeping it out of
+ * CI means that fragility never blocks a PR. Run it by hand before launch and
+ * after any change to the Polar product, benefit, or checkout link.
+ *
+ *   npm run test:checkout                # buy with a test card, then verify
+ *   npm run test:checkout -- --verify-only   # just verify the latest order
+ *   npm run test:checkout -- --headed        # watch it happen
+ *
+ * The sandbox is a separate Polar instance: separate account, organization,
+ * product, benefit, and access token. A production token will not work here.
+ * See https://polar.sh/docs/integrate/sandbox
+ */
+
+import { chromium } from "@playwright/test";
+
+const API = "https://sandbox-api.polar.sh";
+
+/** Stripe's "always succeeds" test card, accepted by the Polar sandbox. */
+const TEST_CARD = {
+  cvc: "123",
+  expiry: "12 / 30",
+  number: "4242 4242 4242 4242",
+  postalCode: "M5V 3L9",
+};
+
+const args = process.argv.slice(2);
+const verifyOnly = args.includes("--verify-only");
+const headed = args.includes("--headed");
+
+const token = process.env.POLAR_SANDBOX_TOKEN;
+const checkoutUrl = process.env.POLAR_SANDBOX_CHECKOUT_URL;
+const benefitId = process.env.POLAR_SANDBOX_BENEFIT_ID;
+const successPath = process.env.POLAR_SANDBOX_SUCCESS_PATH || "/thanks";
+
+const fail = (message) => {
+  console.error(`\n✗ ${message}`);
+  process.exit(1);
+};
+
+const step = (message) => console.log(`\n▸ ${message}`);
+
+/**
+ * Calls the Polar sandbox API.
+ *
+ * @param path - Path below the sandbox API root, e.g. `/v1/orders`.
+ * @returns The parsed JSON body.
+ */
+const api = async (path) => {
+  const response = await fetch(`${API}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    fail(
+      `GET ${path} returned ${response.status} ${response.statusText}. ` +
+        `Check POLAR_SANDBOX_TOKEN is a sandbox token with orders:read and benefits:read.`
+    );
+  }
+
+  return response.json();
+};
+
+/**
+ * Fills Polar's hosted checkout form and submits it.
+ *
+ * The card fields live in Stripe iframes whose exact structure is Stripe's to
+ * change, so this is the one brittle part of the script. On failure it writes
+ * `checkout-smoke-failure.png` so you can see the form it actually got.
+ *
+ * @param page - The Playwright page sitting on the checkout URL.
+ * @param email - The buyer email to register the order against.
+ */
+const completeCheckout = async (page, email) => {
+  await page.getByLabel(/email/i).fill(email);
+
+  // Stripe renders each field in its own iframe; scan them all rather than
+  // assuming an order or a name.
+  const fillInFrames = async (matchers, value) => {
+    for (const frame of page.frames()) {
+      for (const matcher of matchers) {
+        const field = frame.getByPlaceholder(matcher);
+        if ((await field.count()) > 0) {
+          await field.first().fill(value);
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  const filledCard = await fillInFrames(
+    [/1234 1234/, /card number/i],
+    TEST_CARD.number
+  );
+  if (!filledCard) {
+    await page.screenshot({ path: "checkout-smoke-failure.png" });
+    fail(
+      "Could not find the card number field. Polar or Stripe changed the " +
+        "checkout markup — see checkout-smoke-failure.png and update the " +
+        "selectors in completeCheckout()."
+    );
+  }
+
+  await fillInFrames([/MM \/ YY/i, /expir/i], TEST_CARD.expiry);
+  await fillInFrames([/CVC/i, /security code/i], TEST_CARD.cvc);
+  await fillInFrames([/ZIP/i, /postal/i], TEST_CARD.postalCode);
+
+  await page
+    .getByRole("button", { name: /pay|subscribe|purchase|complete/i })
+    .first()
+    .click();
+};
+
+/**
+ * Confirms the sandbox recorded a paid order, and that the benefit was granted.
+ *
+ * This is the durable half of the script — it asserts against the API rather
+ * than the DOM, so it stays valid even when the checkout UI changes.
+ *
+ * @param email - Buyer email to match, or null to check the most recent order.
+ */
+const verify = async (email) => {
+  step("Verifying the order via the sandbox API");
+
+  // Orders are written after the redirect, so give the webhook a moment.
+  let order = null;
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    const { items = [] } = await api("/v1/orders?limit=10&sorting=-created_at");
+    order = email
+      ? items.find((item) => item.customer?.email === email)
+      : items[0];
+
+    if (order) break;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    console.log(`  waiting for the order to appear (${attempt}/10)…`);
+  }
+
+  if (!order) {
+    fail(
+      email
+        ? `No sandbox order found for ${email} after 20s.`
+        : "No sandbox orders found at all."
+    );
+  }
+
+  console.log(`  order ${order.id}`);
+  console.log(`  customer ${order.customer?.email}`);
+  console.log(`  status ${order.status}  paid=${order.paid}`);
+
+  if (order.status !== "paid" && order.paid !== true) {
+    fail(`Order is not paid (status: ${order.status}).`);
+  }
+  console.log("  ✓ order is paid");
+
+  if (!benefitId) {
+    console.log(
+      "\n  (Set POLAR_SANDBOX_BENEFIT_ID to also assert the repo-access grant.)"
+    );
+    return;
+  }
+
+  step("Verifying the benefit grant");
+  const { items: grants = [] } = await api(
+    `/v1/benefits/${benefitId}/grants?is_granted=true&customer_id=${order.customer.id}`
+  );
+
+  if (grants.length === 0) {
+    fail(
+      `Order is paid but benefit ${benefitId} was NOT granted to ${order.customer?.email}. ` +
+        `This is the failure that leaves a real buyer with a receipt and no repository access — ` +
+        `check that Polar's GitHub App is installed on the repository owner's organization.`
+    );
+  }
+
+  console.log(`  ✓ benefit granted (${grants.length} grant(s))`);
+};
+
+const main = async () => {
+  if (!token) {
+    fail(
+      "POLAR_SANDBOX_TOKEN is not set. Create a sandbox token at " +
+        "https://sandbox.polar.sh (Settings → Developers) with orders:read and benefits:read."
+    );
+  }
+
+  if (verifyOnly) {
+    await verify(null);
+    console.log("\n✓ Checkout smoke passed (verify-only)\n");
+    return;
+  }
+
+  if (!checkoutUrl) {
+    fail(
+      "POLAR_SANDBOX_CHECKOUT_URL is not set. Create a checkout link on your " +
+        "sandbox product, or re-run with --verify-only."
+    );
+  }
+
+  const email = `nextstarter-smoke+${Date.now()}@example.com`;
+  const browser = await chromium.launch({ headless: !headed });
+  const page = await browser.newPage();
+
+  try {
+    step(`Opening sandbox checkout as ${email}`);
+    await page.goto(checkoutUrl);
+
+    step("Paying with the test card");
+    await completeCheckout(page, email);
+
+    step(`Waiting for the redirect to ${successPath}`);
+    await page.waitForURL((url) => url.pathname.startsWith(successPath), {
+      timeout: 60000,
+    });
+    console.log(`  landed on ${page.url()}`);
+
+    // The success page is informational, but if it 404s or errors the buyer's
+    // first impression after paying is a broken page.
+    await page.getByRole("heading", { name: /thank you/i }).waitFor();
+    console.log("  ✓ confirmation page rendered");
+  } finally {
+    await browser.close();
+  }
+
+  await verify(email);
+  console.log("\n✓ Checkout smoke passed\n");
+};
+
+main().catch((error) => fail(error.stack || String(error)));

--- a/src/app/thanks/page.tsx
+++ b/src/app/thanks/page.tsx
@@ -1,0 +1,148 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Polar customer portal for this organization. Buyers sign in with the email
+ * they used at checkout (Polar sends a one-time code) to claim their benefits,
+ * re-download invoices, and manage the order.
+ */
+const portalUrl =
+  process.env.NEXT_PUBLIC_POLAR_PORTAL_URL ||
+  "https://polar.sh/742-studios/portal";
+
+/** Where buyers should write if an order or repo invite goes wrong. */
+const supportEmail =
+  process.env.NEXT_PUBLIC_SUPPORT_EMAIL || "bill@billdean.me";
+
+/** The post-purchase steps, rendered as a numbered checklist. */
+const steps = [
+  {
+    body: "Polar emails your receipt and order confirmation right away. If it isn't there within a few minutes, check your spam folder — it comes from Polar, not from NextStarter.",
+    id: 1,
+    title: "Check your inbox",
+  },
+  {
+    body: "Open your customer portal and sign in with the email address you used at checkout. Connect your GitHub account there to claim access to the private NextStarter Pro repository.",
+    id: 2,
+    title: "Claim your repository access",
+  },
+  {
+    body: "GitHub emails you a collaborator invitation for the private repo. Accept it and the repository shows up in your GitHub account — that invite expires, so accept it sooner rather than later.",
+    id: 3,
+    title: "Accept the GitHub invitation",
+  },
+  {
+    body: "Clone the repo, install dependencies, and start the dev server. The README and the docs/ directory cover setup and each optional integration.",
+    id: 4,
+    title: "Clone and start building",
+  },
+];
+
+export const metadata: Metadata = {
+  // Relative — Next resolves it against the metadataBase set in the root layout,
+  // so it stays correct whether or not NEXT_PUBLIC_SITE_URL has a trailing slash.
+  alternates: {
+    canonical: "/thanks",
+  },
+  description:
+    "Your NextStarter Pro purchase is confirmed. Here's how to claim your access to the private repository.",
+  // A post-purchase page has no business in search results, and buyers reach it
+  // only by redirect from Polar checkout.
+  robots: {
+    follow: false,
+    index: false,
+  },
+  title: "Thank you for your purchase",
+};
+
+/**
+ * Post-purchase confirmation page.
+ *
+ * Polar redirects buyers here after a successful checkout (configured as the
+ * Success URL on the checkout link). This page is informational only — access
+ * is granted by Polar's GitHub Repository benefit, never by this page — so it
+ * stays fully static and reads no query parameters.
+ *
+ * @returns The order confirmation page with next steps.
+ */
+const Thanks = () => {
+  return (
+    <div className="min-h-screen pt-16">
+      <main className="mx-auto max-w-5xl px-6 py-24 md:py-32" id="main">
+        <div className="space-y-4 text-center">
+          <span
+            className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-linear-to-br from-orange-700 to-orange-600 text-2xl text-white shadow-lg dark:from-orange-600"
+            aria-hidden="true"
+          >
+            ✓
+          </span>
+          <h2 className="font-serif text-3xl font-bold text-stone-900 md:text-4xl dark:text-stone-50">
+            Thank you for your purchase
+          </h2>
+          <p className="mx-auto max-w-2xl text-lg leading-relaxed text-stone-600 dark:text-stone-300">
+            Your order for <strong>NextStarter Pro</strong> is confirmed. Here
+            is how to get into the private repository and start building.
+          </p>
+        </div>
+
+        <ol className="mx-auto mt-12 max-w-3xl space-y-4">
+          {steps.map((step) => (
+            <li
+              key={step.id}
+              className="flex gap-4 rounded-lg border border-stone-200 bg-white p-6 dark:border-stone-800 dark:bg-stone-900/50"
+            >
+              <span
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-orange-600 font-semibold text-white dark:bg-orange-500"
+                aria-hidden="true"
+              >
+                {step.id}
+              </span>
+              <div className="space-y-2">
+                <h3 className="font-medium text-stone-900 dark:text-stone-50">
+                  {step.title}
+                </h3>
+                <p className="text-stone-600 dark:text-stone-400">
+                  {step.body}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        <div className="mt-12 flex flex-col items-center gap-4">
+          <Button
+            asChild
+            size="lg"
+            className="dark:to-coral-600 bg-linear-to-r from-orange-700 to-orange-600 font-bold text-white shadow-lg transition-all hover:scale-[1.02] hover:shadow-xl active:scale-[0.98] dark:from-orange-600"
+          >
+            <Link href={portalUrl} target="_blank" rel="noopener noreferrer">
+              Open your customer portal
+            </Link>
+          </Button>
+          <p className="text-center text-sm text-stone-600 dark:text-stone-400">
+            Something not right with your order?{" "}
+            <a
+              href={`mailto:${supportEmail}`}
+              className="underline transition-colors hover:text-orange-700 dark:hover:text-orange-400"
+            >
+              Email {supportEmail}
+            </a>{" "}
+            and include the email address you used at checkout.
+          </p>
+          <Link
+            href="/"
+            className="text-sm text-stone-600 underline transition-colors hover:text-orange-700 dark:text-stone-400 dark:hover:text-orange-400"
+          >
+            Back to the home page
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+Thanks.displayName = "Thanks";
+
+export default Thanks;

--- a/src/components/footer/quick-links.tsx
+++ b/src/components/footer/quick-links.tsx
@@ -6,6 +6,7 @@ const quickLinkItems = [
   { href: "#about", id: 1, label: "About" },
   { href: "#stack", id: 2, label: "Tech Stack" },
   { href: "#features", id: 3, label: "Features" },
+  { href: "#pro", id: 5, label: "Upgrade to Pro" },
   { href: "#getting-started", id: 4, label: "Getting Started" },
 ];
 

--- a/src/components/footer/quick-links.tsx
+++ b/src/components/footer/quick-links.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { scrollToSection } from "@/lib/utils";
+import { useScrollToSection } from "@/lib/use-scroll-to-section";
 
 const quickLinkItems = [
   { href: "#about", id: 1, label: "About" },
@@ -16,6 +16,8 @@ const quickLinkItems = [
  * @returns List of quick navigation links with hover effects
  */
 const QuickLinks = () => {
+  const scrollToSection = useScrollToSection();
+
   return (
     <ul className="space-y-2 text-sm">
       {quickLinkItems.map((link) => (

--- a/src/components/header/cta.tsx
+++ b/src/components/header/cta.tsx
@@ -1,16 +1,35 @@
-import { scrollToSection } from "@/lib/utils";
+"use client";
+
+import { useScrollToSection } from "@/lib/use-scroll-to-section";
+
+interface CtaProps {
+  /**
+   * Run after the scroll is requested. The mobile menu passes its close
+   * handler here — it locks body scroll while open, so the menu has to close
+   * for the scroll to actually happen.
+   */
+  onNavigate?: () => void;
+}
 
 /**
  * Call-to-action button component for header
  * Scrolls to the getting started section when clicked
+ * @param onNavigate - Optional callback fired after the scroll is requested
  * @returns CTA button that navigates to getting started section
  */
-const Cta = () => {
+const Cta = ({ onNavigate }: CtaProps) => {
+  const scrollToSection = useScrollToSection();
+
+  const handleClick = () => {
+    scrollToSection("getting-started");
+    onNavigate?.();
+  };
+
   return (
     <button
       type="button"
       className="dark:to-coral-600 hidden rounded-lg bg-linear-to-r from-orange-700 to-orange-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all hover:scale-[1.02] hover:shadow-md active:scale-[0.98] sm:block dark:from-orange-800"
-      onClick={() => scrollToSection("getting-started")}
+      onClick={handleClick}
       aria-label="Get Started"
     >
       Get Started

--- a/src/components/header/mobile-menu.tsx
+++ b/src/components/header/mobile-menu.tsx
@@ -103,7 +103,7 @@ const MobileMenu = ({ isOpen, onClose }: MobileMenuProps) => {
 
         {/* Mobile CTA */}
         <div className="shrink-0 border-t border-stone-200/50 p-6 dark:border-stone-800/50">
-          <Cta />
+          <Cta onNavigate={onClose} />
         </div>
       </div>
     </>

--- a/src/components/header/navigation-items.ts
+++ b/src/components/header/navigation-items.ts
@@ -2,4 +2,5 @@ export const navigationItems = [
   { href: "#about", id: 3, label: "About" },
   { href: "#stack", id: 2, label: "Tech Stack" },
   { href: "#features", id: 1, label: "Features" },
+  { href: "#pro", id: 4, label: "Pro" },
 ];

--- a/src/components/header/navigation.tsx
+++ b/src/components/header/navigation.tsx
@@ -1,4 +1,6 @@
-import { scrollToSection } from "@/lib/utils";
+"use client";
+
+import { useScrollToSection } from "@/lib/use-scroll-to-section";
 
 import { navigationItems } from "./navigation-items";
 
@@ -8,6 +10,8 @@ import { navigationItems } from "./navigation-items";
  * @returns Navigation menu with smooth scroll buttons (hidden on mobile)
  */
 const Navigation = () => {
+  const scrollToSection = useScrollToSection();
+
   return (
     <nav className="hidden items-center gap-6 md:flex">
       <ul className="hidden space-x-6 md:flex md:items-center">

--- a/src/components/landing-page/index.tsx
+++ b/src/components/landing-page/index.tsx
@@ -2,6 +2,7 @@ import About from "./about";
 import Features from "./features";
 import GettingStarted from "./getting-started";
 import Stack from "./stack";
+import Upgrade from "./upgrade";
 
 /**
  * Default home page component displaying project features and installation instructions
@@ -19,6 +20,8 @@ const LandingPage = () => {
       <Stack />
 
       <Features />
+
+      <Upgrade />
 
       <GettingStarted />
     </>

--- a/src/components/landing-page/index.tsx
+++ b/src/components/landing-page/index.tsx
@@ -1,6 +1,7 @@
 import About from "./about";
 import Features from "./features";
 import GettingStarted from "./getting-started";
+import ScrollTargetRestorer from "./scroll-target-restorer";
 import Stack from "./stack";
 import Upgrade from "./upgrade";
 
@@ -11,6 +12,7 @@ import Upgrade from "./upgrade";
 const LandingPage = () => {
   return (
     <>
+      <ScrollTargetRestorer />
       <h2 className="sr-only">
         NextStarter - A modern Next.js boilerplate for building production-ready
         web applications.

--- a/src/components/landing-page/scroll-target-restorer.tsx
+++ b/src/components/landing-page/scroll-target-restorer.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { consumePendingScrollTarget } from "@/lib/use-scroll-to-section";
+import { scrollToSection } from "@/lib/utils";
+
+/**
+ * Completes a section navigation that started on another route.
+ *
+ * Nav links outside the home page stash their target section and route here
+ * (see `useScrollToSection`). This picks the target back up once the landing
+ * page has mounted and scrolls to it. Renders nothing.
+ *
+ * @returns Nothing — this component only runs an effect.
+ */
+const ScrollTargetRestorer = () => {
+  useEffect(() => {
+    // Wait a frame so the sections below have been laid out; scrolling during
+    // the mount commit lands at the wrong offset.
+    //
+    // Read the target inside the frame, not out here: Strict Mode runs this
+    // effect, cleans it up, then runs it again. Consuming in the effect body
+    // would clear the target on the first pass and cancel the frame that was
+    // going to use it, leaving the second pass with nothing to scroll to.
+    const frame = requestAnimationFrame(() => {
+      const sectionId = consumePendingScrollTarget();
+
+      if (sectionId) scrollToSection(sectionId);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  return null;
+};
+
+ScrollTargetRestorer.displayName = "ScrollTargetRestorer";
+
+export default ScrollTargetRestorer;

--- a/src/components/landing-page/upgrade.tsx
+++ b/src/components/landing-page/upgrade.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+/** What the free (lite) starter includes. */
+const freeFeatures = [
+  "Marketing landing page (Next.js 16, TypeScript, Tailwind v4)",
+  "Light & dark theming with ShadCN/UI",
+  "WCAG 2.1 AA accessibility, verified with Axe-core",
+  "Playwright end-to-end tests + GitHub Actions CI",
+  "SEO essentials: robots.txt, sitemap.xml, custom 404",
+];
+
+/** What Pro adds on top of the free starter. */
+const proFeatures = [
+  "Authentication with Clerk (sign-in, protected routes, profile)",
+  "Database with Prisma + PostgreSQL (user-owned CRUD example)",
+  "Transactional email (Resend) & Stripe subscriptions",
+  "Dashboard app shell + protected admin panel",
+  "MDX blog + validated contact form",
+  "Internationalization — English, Spanish, Arabic (RTL)",
+  "Security headers, CSP & API rate limiting",
+  "Waitlist mode, PostHog analytics & Sentry error tracking",
+  "Comprehensive documentation",
+];
+
+/** The destination for the upgrade CTA (marketing / purchase page). */
+const proUrl = process.env.NEXT_PUBLIC_PRO_URL || "https://www.nextstarter.app/";
+
+/** A single checklist row shared by both plan cards. */
+const PlanItem = ({ children }: { children: React.ReactNode }) => (
+  <li className="flex items-start gap-3">
+    <span
+      className="mt-0.5 text-orange-600 dark:text-orange-400"
+      aria-hidden="true"
+    >
+      ✓
+    </span>
+    <span>{children}</span>
+  </li>
+);
+
+/**
+ * Upgrade section comparing the free (lite) starter with NextStarter Pro.
+ *
+ * Presents a two-column Free vs. Pro comparison and a call to action to purchase
+ * the full version. The CTA target is env-driven ({@link proUrl}) so it can point
+ * at the marketing site or a checkout page without a code change.
+ *
+ * @returns The Free vs. Pro comparison section.
+ */
+const Upgrade = () => {
+  return (
+    <>
+      <section className="mx-auto max-w-5xl px-6 py-24 md:py-32" id="pro">
+        <div className="space-y-4 text-center">
+          <h2 className="font-serif text-3xl font-bold text-stone-900 md:text-4xl dark:text-stone-50">
+            Upgrade to NextStarter Pro
+          </h2>
+          <p className="mx-auto max-w-2xl text-lg leading-relaxed text-stone-600 dark:text-stone-300">
+            You&apos;re looking at the free version. Pro turns this starter into a
+            complete SaaS foundation — authentication, database, payments, email,
+            a dashboard, and more — so you can go from clone to launch in days,
+            not weeks.
+          </p>
+        </div>
+
+        <div className="mt-12 grid gap-6 md:grid-cols-2">
+          {/* Free plan */}
+          <div className="flex flex-col rounded-2xl border border-stone-200 bg-white p-8 dark:border-stone-800 dark:bg-stone-900/50">
+            <div className="space-y-1">
+              <h3 className="font-serif text-xl font-bold text-stone-900 dark:text-stone-50">
+                Free
+              </h3>
+              <p className="text-3xl font-bold text-stone-900 dark:text-stone-50">
+                $0
+              </p>
+              <p className="text-sm text-stone-500 dark:text-stone-400">
+                This starter — yours to build on.
+              </p>
+            </div>
+            <ul className="mt-6 flex-1 space-y-3 text-stone-600 dark:text-stone-300">
+              {freeFeatures.map((feature) => (
+                <PlanItem key={feature}>{feature}</PlanItem>
+              ))}
+            </ul>
+            <p className="mt-8 text-center text-sm font-medium text-stone-500 dark:text-stone-400">
+              You&apos;re already here 🎉
+            </p>
+          </div>
+
+          {/* Pro plan */}
+          <div className="relative flex flex-col rounded-2xl border-2 border-orange-300 bg-white p-8 shadow-lg dark:border-orange-800/70 dark:bg-stone-900/50">
+            <span className="absolute -top-3 left-8 rounded-full bg-linear-to-r from-orange-700 to-orange-600 px-3 py-1 text-xs font-semibold text-white dark:from-orange-600">
+              Most complete
+            </span>
+            <div className="space-y-1">
+              <h3 className="font-serif text-xl font-bold text-stone-900 dark:text-stone-50">
+                Pro
+              </h3>
+              <p className="text-3xl font-bold text-stone-900 dark:text-stone-50">
+                $199{" "}
+                <span className="text-base font-normal text-stone-500 dark:text-stone-400">
+                  one-time
+                </span>
+              </p>
+              <p className="text-sm text-stone-500 dark:text-stone-400">
+                Lifetime access &amp; updates via a private GitHub repo.
+              </p>
+            </div>
+            <ul className="mt-6 flex-1 space-y-3 text-stone-700 dark:text-stone-200">
+              <PlanItem>
+                <span className="font-medium">Everything in Free, plus:</span>
+              </PlanItem>
+              {proFeatures.map((feature) => (
+                <PlanItem key={feature}>{feature}</PlanItem>
+              ))}
+            </ul>
+            <div className="mt-8 flex justify-center">
+              <Button
+                asChild
+                size="lg"
+                className="dark:to-coral-600 w-full bg-linear-to-r from-orange-700 to-orange-600 font-bold text-white shadow-lg transition-all hover:scale-[1.02] hover:shadow-xl active:scale-[0.98] dark:from-orange-600"
+              >
+                <Link href={proUrl} target="_blank" rel="noopener noreferrer">
+                  Get NextStarter Pro
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+      {/* Divider */}
+      <div className="mx-auto h-px w-full max-w-5xl bg-linear-to-r from-transparent via-stone-200 to-transparent dark:via-stone-800" />
+    </>
+  );
+};
+
+Upgrade.displayName = "Upgrade";
+
+export default Upgrade;

--- a/src/lib/use-scroll-to-section.ts
+++ b/src/lib/use-scroll-to-section.ts
@@ -33,3 +33,21 @@ export const useScrollToSection = () => {
     [pathname, router]
   );
 };
+
+/**
+ * Reads and clears the section stashed by {@link useScrollToSection}.
+ *
+ * Clearing on read means the scroll happens once, on the navigation that
+ * requested it, and not again on a later reload of the home page.
+ *
+ * @returns The pending section id, or `null` when there isn't one.
+ */
+export const consumePendingScrollTarget = () => {
+  const sectionId = sessionStorage.getItem(SCROLL_TARGET_KEY);
+
+  if (sectionId) {
+    sessionStorage.removeItem(SCROLL_TARGET_KEY);
+  }
+
+  return sectionId;
+};

--- a/tests/cross-route-navigation.spec.ts
+++ b/tests/cross-route-navigation.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The header nav, footer quick links, and Get Started CTA all point at sections
+ * of the landing page. From any other route (/thanks, a 404) they have to route
+ * home first and then scroll — these cover that second half.
+ */
+test.describe("Section navigation from a non-home route", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/thanks");
+  });
+
+  test("Header nav link routes home and scrolls to the section", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "Features" })
+      .click();
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("section#features")).toBeInViewport();
+  });
+
+  test("Footer quick link routes home and scrolls to the section", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Upgrade to Pro" }).click();
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("section#pro")).toBeInViewport();
+  });
+
+  test("Get Started CTA routes home and scrolls to Getting Started", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Get Started" }).click();
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("section#getting-started")).toBeInViewport();
+  });
+
+  test("The stashed section is consumed, so it is not replayed later", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "Features" })
+      .click();
+    await expect(page.locator("section#features")).toBeInViewport();
+
+    // Reading the target clears it...
+    const pendingTarget = await page.evaluate(() =>
+      sessionStorage.getItem("nextstarter:scroll-target")
+    );
+    expect(pendingTarget).toBeNull();
+
+    // ...so simply arriving at the home page again lands at the top. (Asserted
+    // via a fresh navigation rather than a reload: Chromium restores the prior
+    // scroll offset on reload, which would test the browser, not this code.)
+    await page.goto("/thanks");
+    await page.goto("/");
+
+    await expect(page.locator("section#about")).toBeInViewport();
+    await expect(page.locator("section#features")).not.toBeInViewport();
+  });
+});

--- a/tests/home-page-header-and-sections.spec.ts
+++ b/tests/home-page-header-and-sections.spec.ts
@@ -33,9 +33,7 @@ test.describe("Home page sections", () => {
     ).toBeVisible();
 
     await nav.getByRole("button", { name: "Features" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Features" })
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Features" })).toBeVisible();
   });
 });
 
@@ -47,7 +45,10 @@ test.describe("Home page navigation scroll behavior", () => {
   test("About nav link scrolls the About section into view", async ({
     page,
   }) => {
-    await page.getByRole("navigation").getByRole("button", { name: "About" }).click();
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "About" })
+      .click();
 
     await expect(page.locator("section#about")).toBeInViewport();
     await expect(
@@ -58,7 +59,10 @@ test.describe("Home page navigation scroll behavior", () => {
   test("Tech Stack nav link scrolls the Tech Stack section into view", async ({
     page,
   }) => {
-    await page.getByRole("navigation").getByRole("button", { name: "Tech Stack" }).click();
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "Tech Stack" })
+      .click();
 
     await expect(page.locator("section#stack")).toBeInViewport();
     await expect(
@@ -69,7 +73,10 @@ test.describe("Home page navigation scroll behavior", () => {
   test("Features nav link scrolls the Features section into view", async ({
     page,
   }) => {
-    await page.getByRole("navigation").getByRole("button", { name: "Features" }).click();
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "Features" })
+      .click();
 
     await expect(page.locator("section#features")).toBeInViewport();
     await expect(
@@ -104,5 +111,39 @@ test.describe("Home page section item counts", () => {
 
   test("Getting Started section displays 4 steps", async ({ page }) => {
     await expect(page.locator("section#getting-started ol li")).toHaveCount(4);
+  });
+});
+
+test.describe("Home page upgrade (Pro) section", () => {
+  test("Pro nav link scrolls the upgrade section into view", async ({
+    page,
+  }) => {
+    await page.goto("./");
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "Pro" })
+      .click();
+
+    await expect(page.locator("section#pro")).toBeInViewport();
+    await expect(
+      page.getByRole("heading", { name: "Upgrade to NextStarter Pro" })
+    ).toBeInViewport();
+  });
+
+  test("shows Free and Pro plans with an external Get Pro CTA", async ({
+    page,
+  }) => {
+    await page.goto("./");
+    const pro = page.locator("section#pro");
+
+    await expect(pro.getByRole("heading", { name: "Free" })).toBeVisible();
+    await expect(
+      pro.getByRole("heading", { exact: true, name: "Pro" })
+    ).toBeVisible();
+
+    const cta = pro.getByRole("link", { name: "Get NextStarter Pro" });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("target", "_blank");
+    expect(await cta.getAttribute("href")).toMatch(/^https?:\/\//);
   });
 });

--- a/tests/home-page-header-and-sections.spec.ts
+++ b/tests/home-page-header-and-sections.spec.ts
@@ -146,4 +146,34 @@ test.describe("Home page upgrade (Pro) section", () => {
     await expect(cta).toHaveAttribute("target", "_blank");
     expect(await cta.getAttribute("href")).toMatch(/^https?:\/\//);
   });
+
+  test("Get Pro CTA points at the configured purchase URL, off this site", async ({
+    page,
+  }) => {
+    const proUrl = process.env.NEXT_PUBLIC_PRO_URL;
+
+    // Skips where the purchase URL isn't configured — a fresh clone of this
+    // starter has no checkout link of its own yet.
+    test.skip(
+      !proUrl,
+      "NEXT_PUBLIC_PRO_URL is not set in this environment; nothing to verify"
+    );
+
+    await page.goto("./");
+    const href = await page
+      .locator("section#pro")
+      .getByRole("link", { name: "Get NextStarter Pro" })
+      .getAttribute("href");
+
+    // Catches a build that didn't pick the variable up.
+    expect(href).toBe(proUrl);
+
+    // Catches the failure that silently kills sales: the component falls back
+    // to the marketing site when the variable is missing, so the buy button
+    // links to the very page it sits on and every test above still passes.
+    const siteOrigin = new URL(
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).origin;
+    expect(new URL(href as string).origin).not.toBe(siteOrigin);
+  });
 });

--- a/tests/mobile-menu.spec.ts
+++ b/tests/mobile-menu.spec.ts
@@ -1,0 +1,61 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+/**
+ * The mobile menu locks body scroll while it is open, so every link inside it
+ * has to close the menu for the resulting scroll to actually land.
+ */
+test.describe("Mobile menu navigation", () => {
+  const openMenu = async (page: Page) => {
+    await page.getByRole("button", { name: "Open menu" }).click();
+    await expect(
+      page.getByRole("button", { name: "Close menu" })
+    ).toBeInViewport();
+  };
+
+  test.describe("On a phone viewport", () => {
+    test.use({ viewport: { height: 844, width: 390 } });
+
+    test("A nav link from another route closes the menu, routes home, and scrolls", async ({
+      page,
+    }) => {
+      await page.goto("/thanks");
+      await openMenu(page);
+
+      // Scoped to the menu's nav — the footer quick links repeat these labels.
+      await page
+        .getByRole("navigation")
+        .getByRole("button", { name: "Features" })
+        .click();
+
+      await expect(page).toHaveURL(/\/$/);
+      await expect(
+        page.getByRole("button", { name: "Close menu" })
+      ).not.toBeInViewport();
+      await expect(page.locator("section#features")).toBeInViewport();
+    });
+  });
+
+  test.describe("On a small tablet viewport", () => {
+    // The menu's Get Started button inherits the header CTA's `hidden sm:block`,
+    // so it only renders between the `sm` (640px) and `md` (768px) breakpoints —
+    // the band where the mobile menu is still in use.
+    test.use({ viewport: { height: 900, width: 700 } });
+
+    test("Get Started closes the menu and scrolls to Getting Started", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await openMenu(page);
+
+      // At this width the header's own CTA is visible too; the menu renders
+      // after the header, so the menu's copy is the last one in the DOM.
+      await page.getByRole("button", { name: "Get Started" }).last().click();
+
+      await expect(
+        page.getByRole("button", { name: "Close menu" })
+      ).not.toBeInViewport();
+      await expect(page.locator("section#getting-started")).toBeInViewport();
+    });
+  });
+});

--- a/tests/thanks-page.spec.ts
+++ b/tests/thanks-page.spec.ts
@@ -1,0 +1,90 @@
+/* eslint-disable no-console */
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Thanks page", () => {
+  test("Verify the confirmation content and next steps are shown", async ({
+    page,
+  }) => {
+    // Polar appends the checkout session id to the Success URL; the page must
+    // render identically with or without it.
+    await page.goto("/thanks?checkout_id=polar_c_test123");
+
+    await expect(
+      page.getByRole("heading", { name: "Thank you for your purchase" })
+    ).toBeVisible();
+
+    const steps = page.getByRole("listitem").filter({
+      has: page.getByRole("heading", { level: 3 }),
+    });
+    await expect(steps).toHaveCount(4);
+    await expect(
+      page.getByRole("heading", { name: "Claim your repository access" })
+    ).toBeVisible();
+
+    const portalLink = page.getByRole("link", {
+      name: "Open your customer portal",
+    });
+    await expect(portalLink).toHaveAttribute("href", /polar\.sh/);
+    await expect(portalLink).toHaveAttribute("target", "_blank");
+    await expect(portalLink).toHaveAttribute("rel", /noopener/);
+
+    await expect(page.getByRole("link", { name: /^Email / })).toHaveAttribute(
+      "href",
+      /^mailto:/
+    );
+  });
+
+  test("Verify the page is not indexable and links home", async ({ page }) => {
+    await page.goto("/thanks");
+
+    console.log("Checking metadata on the thanks page");
+
+    const title = await page.title();
+    expect(title).toBe("Thank you for your purchase | NextStarter");
+
+    // A post-purchase page should never appear in search results.
+    const robotsMeta = await page
+      .locator('meta[name="robots"]')
+      .getAttribute("content");
+    expect(robotsMeta).toContain("noindex");
+
+    await page.getByRole("link", { name: "Back to the home page" }).click();
+    await expect(page).toHaveURL(/\/$/);
+  });
+});
+
+test.describe("Thanks page does not have accessiblity issues", () => {
+  test("Should not have any automatically detectable accessibility issues", async ({
+    page,
+  }) => {
+    await page.goto("/thanks");
+
+    console.log("Running accessibility scan on the thanks page");
+
+    // Test light mode
+    const lightModeClass = await page.locator("html").getAttribute("class");
+    expect(lightModeClass).toContain("light");
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+
+    // Test dark mode
+    const themeToggle = page.locator("#themeToggle");
+    await themeToggle.first().click();
+    console.log("Switching to Dark mode for accessibility testing");
+    const darkModeClass = await page.locator("html").getAttribute("class");
+    expect(darkModeClass).toContain("dark");
+
+    // The click leaves the toggle focused, which opens its tooltip (Firefox
+    // keeps focus after a programmatic click; Chromium does not). Drop focus
+    // and wait for the tooltip to close so the scan runs on a stable page
+    // rather than a transient, mid-animation tooltip.
+    await themeToggle.first().blur();
+    await expect(page.getByRole("tooltip")).toHaveCount(0);
+
+    const darkModeAccessibilityScanResults = await new AxeBuilder({
+      page,
+    }).analyze();
+    expect(darkModeAccessibilityScanResults.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
Add a Free vs. Pro comparison section to the landing page pitching the full NextStarter Pro version:

- New Upgrade section (src/components/landing-page/upgrade.tsx) with a free ($0) column listing what this starter ships and a Pro ($199 one-time) column listing the premium features (auth, database, email, Stripe, dashboard + admin, blog, contact, i18n/RTL, security, waitlist, analytics, error tracking, docs).
- "Get NextStarter Pro" CTA points at NEXT_PUBLIC_PRO_URL (defaults to the marketing site); documented in .env.example.
- "Pro" link added to the header/mobile nav and footer (scrolls to #pro).
- README: top callout + an "Upgrade to Pro" section.
- Playwright coverage for the new section (nav scroll + Free/Pro plans and external CTA); Axe a11y scan stays clean in light and dark.